### PR TITLE
added a hyperlink parser to solving the hyperlink action in review page

### DIFF
--- a/davinci.review/WebContent/davinci/review/editor/Context.js
+++ b/davinci.review/WebContent/davinci/review/editor/Context.js
@@ -233,7 +233,7 @@ dojo.declare("davinci.review.editor.Context", null, {
 				if(evt.target.tagName == 'a' || evt.target.tagName == 'A'){
 					item = (evt.target.nodeType == 3) ? evt.target.parentNode : evt.target;
 					var linkAttr = dojo.attr(item, "href");
-					if (linkAttr.indexOf("http") != -1){
+					if (this.isExternalURL(linkAttr) == true){
 						//console.log("it's an external link");
 						dojo.attr(item, "target", "new");
 					}else{
@@ -247,12 +247,12 @@ dojo.declare("davinci.review.editor.Context", null, {
 								'fileName': linkFilePath
 							}
 						});
-						console.log("file exists: " + result);
+						//console.log("file exists: " + result);
 						
 						if (result == true ){
 							if (targetAttr && (targetAttr.indexOf("new")!=-1)){
 								//console.log("it's an internal link opened in new target");
-								dojo.attr(item, "href", "#");
+								dojo.attr(item, "href", "");
 								dojo.attr(item, "target", "");
 								var originalFileName = this.resourceFile.name;
 								var node = new Object(this.resourceFile);
@@ -276,7 +276,7 @@ dojo.declare("davinci.review.editor.Context", null, {
 								}
 							}
 						}else{
-							dojo.attr(item, "href", "#");
+							dojo.attr(item, "href", "");
 							if(!this.warningDialog){
 			            		this.warningDialog = new dijit.Dialog({
 			            			title: langObj.warning,
@@ -292,6 +292,19 @@ dojo.declare("davinci.review.editor.Context", null, {
 				}
 			}))
 		);
+	},
+	
+	isExternalURL: function(url){
+		if (url.indexOf("http") != -1){
+			var localhost = window.location.host;
+			if (url.indexOf(localhost)!= -1){
+				return false;
+			}else{
+				return true;
+			}
+		}else{
+			return false;
+		}
 	}
 });
 

--- a/davinci.review/WebContent/davinci/review/editor/ReviewEditor.js
+++ b/davinci.review/WebContent/davinci/review/editor/ReviewEditor.js
@@ -67,6 +67,7 @@ dojo.declare("davinci.review.editor.ReviewEditor", davinci.ui.ModelEditor, {
 
 		this.title = dojo.doc.title;
 	   	this.context.setSource();
+	   	this.context.parseHyperlink();
 	},
 	
 	destroy : function (){

--- a/davinci.review/WebContent/davinci/review/widgets/nls/widgets.js
+++ b/davinci.review/WebContent/davinci/review/widgets/nls/widgets.js
@@ -75,6 +75,8 @@
 		
 		//MailFailurDialogContent.html
 		"inviteNotSent":"Invitation was not sent",
-		"mailFailureMsg":"It seems that the mail service is down or not configured. Please copy the invitation below and send it manually."
-
+		"mailFailureMsg":"It seems that the mail service is down or not configured. Please copy the invitation below and send it manually.",
+		
+		//Context.js
+		"pageMissed" : "The linked page doesn't exist!"
 })

--- a/davinci.review/plugin.xml
+++ b/davinci.review/plugin.xml
@@ -40,7 +40,9 @@
          <command path="managerVersion"
          	   class="org.davinci.server.review.command.ManagerVersion" />
          <command path="getReviewUserInfo"
-         	   class="org.davinci.server.review.command.GetReviewUserInfo" />   
+         	   class="org.davinci.server.review.command.GetReviewUserInfo" />
+		 <command path="detectLinkedFile"
+         	   class="org.davinci.server.review.command.DetectLinkedFile" />
       </extension>
             <extension
             point="davinci.core.jsPlugin">

--- a/davinci.review/src/org/davinci/server/review/command/DetectLinkedFile.java
+++ b/davinci.review/src/org/davinci/server/review/command/DetectLinkedFile.java
@@ -1,0 +1,27 @@
+package org.davinci.server.review.command;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.davinci.server.Command;
+import org.davinci.server.IDavinciServerConstants;
+import org.davinci.server.user.User;
+
+public class DetectLinkedFile extends Command {
+
+	@Override
+	public void handleCommand(HttpServletRequest req, HttpServletResponse resp,
+			User user) throws IOException {
+		
+		String base = System.getProperty(IDavinciServerConstants.BASE_DIRECTORY_PROPERTY);
+		String filePath = base + "/" + req.getParameter("fileName");
+		
+		File file = new File(filePath);
+		//System.out.println(filePath + ":" + file.exists());
+		this.responseString = String.valueOf(file.exists());
+	}
+
+}


### PR DESCRIPTION
added a hyperlink parser to solving the hyperlink action in review page. Now it's process and logic is like this.
1. hyperlink to a external page.
-- open a new window/tap directly.
2. hyperlink to a local page opened in same target
-- open the page in current editor and refresh related comments components
3. hyperlink to a local page opened in new target
-- open the page in a new tab for reviewing
4. hyperlink to a unexisting local page
-- do nothing except showing a page linked error dialog.
