### PR TITLE
Better code when changing Dojox Mobile CSS files.

### DIFF
--- a/davinci.core/WebContent/davinci/ve/Context.js
+++ b/davinci.core/WebContent/davinci/ve/Context.js
@@ -356,16 +356,13 @@ dojo.declare("davinci.ve.Context", null, {
      * @param force {boolean} if true, forces setting of CSS files, even if
      *              'device' is the same as the current device
      */
-	setMobileTheme: function(device, force) {
+	setMobileTheme: function(device) {
 	    function getDeviceCssFiles(dev) {
 	        var name = preview.silhouetteiframe.getMobileTheme(dev + '.svg');
 	        return preview.silhouetteiframe.getMobileCss(name);
 	    }
 
         var oldDevice = this.getMobileDevice() || 'none';
-        if (oldDevice === device && ! force) {
-            return;
-        }
 
 		var libVer = davinci.ve.metadata.getLibrary('dojo').version;
 		var lib = this.getLibraryBase('dojo', libVer);
@@ -720,7 +717,7 @@ dojo.declare("davinci.ve.Context", null, {
 					var onload = dojo.connect(this, 'onload', function() {
 						var mobileDevice = context.getMobileDevice();
 	                    if (mobileDevice) {
-                            context._editor.visualEditor.setDevice(mobileDevice, true);
+                            context._editor.visualEditor.setDevice(mobileDevice);
 	                    }
 	                    dojo.disconnect(onload);
 					});

--- a/davinci.core/WebContent/davinci/ve/VisualEditor.js
+++ b/davinci.core/WebContent/davinci/ve/VisualEditor.js
@@ -75,7 +75,7 @@ dojo.declare("davinci.ve.VisualEditor", null, {
 		});
 	},
 	
-	setDevice: function(deviceName, force) {
+	setDevice: function(deviceName) {
 	    this.deviceName = deviceName;
 	    var svgfilename;
 	    if(deviceName=='none'){
@@ -85,7 +85,7 @@ dojo.declare("davinci.ve.VisualEditor", null, {
 	    	svgfilename = "app/preview/images/"+deviceName+".svg";
 	    }
 		this.silhouetteiframe.setSVGFilename(svgfilename);
-		this.getContext().setMobileTheme(deviceName, force);
+		this.getContext().setMobileTheme(deviceName);
 
 		// #683 - When using mobile silhouette, add mobile <meta> tags to
 		// document.

--- a/davinci.dojo_1_7/WebContent/metadata/dojox/mobile/MobileCreateTool.js
+++ b/davinci.dojo_1_7/WebContent/metadata/dojox/mobile/MobileCreateTool.js
@@ -8,8 +8,49 @@ dojo.declare("davinci.libraries.dojo.dojox.mobile.MobileCreateTool", davinci.ve.
     // override CreateTool.create() to force the the update of the css files to the correct mobile theme
     create: function(args) {
         this.inherited(arguments);
-        var mobileDevice = this._context.getMobileDevice() || 'none';
-		this._context.setMobileTheme(mobileDevice);
+
+        var context = this._context,
+            device = context.getMobileDevice() || 'none';
+        if (device !== 'none' && device !== 'iphone') {
+            this._whenIphoneCssLoaded(function() {
+                context.setMobileTheme(device);
+            });
+        }
+    },
+
+    /**
+     * Invoke the given callback function when the mobile CSS files are ready.
+     *
+     * If 'iphone.css' has just been added to the page, then 'callback' will
+     * only be invoked when the style sheet is fully loaded. If there is no
+     * such file (i.e. user is displaying a non-iphone device), 'callback' is
+     * invoked immediately.
+     *
+     * @param callback {Function}
+     */
+    _whenIphoneCssLoaded: function(callback) {
+        var doc = this._context.getDocument(),
+            reIphoneCss = /\/iphone.css/;
+
+        function poll() {
+            try {
+                dojo.some(doc.styleSheets, function(sheet) {
+                    if (reIphoneCss.test(sheet.href)) {
+                        sheet.cssRules;
+                        return true; // break loop
+                    }
+                });
+
+                // invoke callback
+                try {
+                    callback();
+                } catch(e) {}
+            } catch(e) {
+                setTimeout(poll, 50);
+            }
+        }
+
+        poll();
     }
 
 });


### PR DESCRIPTION
> Remove check in setMobileTheme() that returned immediately
> if incoming device is same as current -- this caused
> problems.
> Change MobileCreateTool to check for 'iphone.css' loaded
> before making CSS changes.
> # 980

OK, I finally think I've got it here.  I tried every permutation of changing devices and it seems to be fine. @JonFerraiolo @peller, would appreciate it if you could take a look, maybe even test it locally.  Might be too late for **M3**, but would be nice to get in.

When adding a Dojox Mobile widget to the page for the first time, the page can either be _normal_ or have a device silhouette.

Normal case: **deviceTheme.js** gets added to page, which loads **iphone.css**.  Nothing to do in this case
 (see `device !== 'none'` check in `MobileCreateTool.create()`).

Device case: A device style sheet is already added to page (probably incorrectly, since no Dojox Mobile widget has yet been added).  When mobile widget is added to page, it adds **deviceTheme.js**, which adds **iphone.css**.  There may now be 2 mobile style sheets on the page: non-iphone and **iphone.css**.

If device is iPhone, nothing to do here either.  In the non-iphone case, the `MobileCreateTool` code goes into effect -- it waits for **iphone.css** to load, then calls `setMobileTheme()`, which removes **iphone.css** and adds the device style sheet, if necessary.
