### PR TITLE
1011 dojox mobile devicetheme

### DIFF
--- a/davinci.core/WebContent/davinci/ve/Context.js
+++ b/davinci.core/WebContent/davinci/ve/Context.js
@@ -54,16 +54,24 @@ dojo.declare("davinci.ve.Context", null, {
 		// monitoring of which stylesheets get loaded for a given theme
 
 		var dm = this.getDojo().getObject("dojox.mobile", true);
-		dm.configDeviceTheme = dojo.hitch(this, function(){
+		dm.configDeviceTheme = dojo.hitch(this, function() {
 			var loadDeviceTheme = dm.loadDeviceTheme;
-			// add before advice
+
+			// Pull in _compat.js immediately, since it redefines methods like loadCssFile which we wish to add advice to now
+			this.getDojo()["require"]("dojox.mobile.compat");
+
+			// add before advice to clear out css file list before loading a new theme
 			dm.loadDeviceTheme = dojo.hitch(this, function(device) {
 				this._dojoxMobileCss = [];
 				loadDeviceTheme(device);
 			});
-			dojo.connect(dm, "loadCssFile", this, function(file){
+
+			// keep an updated list as dojox.mobile loads css files
+			dojo.connect(dm, "loadCssFile", this, function(file) {
 				this._dojoxMobileCss.push(file);
 			});
+
+			// This is a call-once function
 			delete dm.configDeviceTheme;
 		});
 
@@ -369,6 +377,7 @@ dojo.declare("davinci.ve.Context", null, {
      * @param device {?string} device name
      */
     setMobileDevice: function(device) {
+        this.getDojo().config.mblUserAgent = /* remove this line for Dojo 1.7 final */
         this.getDojo()["require"]("dojo/_base/config")["mblUserAgent"] = preview.silhouetteiframe.getMobileTheme(device + '.svg');
         var bodyElement = this.getDocumentElement().getChildElement("body");
         if (! device || device === 'none') {

--- a/davinci.core/WebContent/davinci/ve/VisualEditor.js
+++ b/davinci.core/WebContent/davinci/ve/VisualEditor.js
@@ -75,7 +75,7 @@ dojo.declare("davinci.ve.VisualEditor", null, {
 		});
 	},
 	
-	setDevice: function(deviceName, force) {
+	setDevice: function(deviceName) {
 	    this.deviceName = deviceName;
 	    var svgfilename;
 	    if(deviceName=='none'){
@@ -85,7 +85,7 @@ dojo.declare("davinci.ve.VisualEditor", null, {
 	    	svgfilename = "app/preview/images/"+deviceName+".svg";
 	    }
 		this.silhouetteiframe.setSVGFilename(svgfilename);
-		this.getContext().setMobileTheme(deviceName, force);
+		this.getContext().setMobileTheme(deviceName);
 
 		// #683 - When using mobile silhouette, add mobile <meta> tags to
 		// document.

--- a/davinci.dojo_1_7/WebContent/dojo/dojox/mobile/deviceTheme.js
+++ b/davinci.dojo_1_7/WebContent/dojo/dojox/mobile/deviceTheme.js
@@ -10,13 +10,13 @@ dojox.mobile.loadCssFile=function(_6){
 _1.create("LINK",{href:_6,type:"text/css",rel:"stylesheet"},_1.doc.getElementsByTagName("head")[0]);
 };
 dojox.mobile.themeMap=dojox.mobile.themeMap||[["Android","android",[]],["BlackBerry","blackberry",[]],["iPad","iphone",[_1.moduleUrl("dojox.mobile","themes/iphone/ipad.css")]],["Custom","custom",[]],[".*","iphone",[]]];
-dojox.mobile.loadDeviceTheme=function(){
+dojox.mobile.loadDeviceTheme=function(ua){
 var t=_1.config["mblThemeFiles"]||dojox.mobile.themeFiles||["@theme"];
 if(!_1.isArray(t)){
 }
 var i,j;
 var m=dojox.mobile.themeMap;
-var ua=(location.search.match(/theme=(\w+)/))?RegExp.$1:navigator.userAgent;
+ua=ua||_1.config["mblUserAgent"]||(location.search.match(/theme=(\w+)/)?RegExp.$1:navigator.userAgent);
 for(i=0;i<m.length;i++){
 if(ua.match(new RegExp(m[i][0]))){
 var _7=m[i][1];


### PR DESCRIPTION
This branch addresses the issue of keeping the dojox mobile theme files in synch when we switch themes and removes direct knowledge of path names from Maqetta code.  It also removes many of our workarounds from the past few weeks, including the 'force' switch.  Instead, AOP-style advice is used to watch dojox.mobile as it loads its themes, then we can easily query and remove them before the theme is switched, letting dojox.mobile do all that work.

I backported dojox.mobile code to allow specifying a "user agent" to dojox.mobile's theme loading routines

Also,  I had to directly load the compat layer to avoid a problem with it redefining a key method, loadCssFile, after the advice is set up.

All in all, it's less code than we had before, and it seems to work well. 
