### PR TITLE
Corrects a logic error in davinci.commands.CommandStack.jump

### DIFF
--- a/maqetta.core.client/WebContent/davinci/commands/CommandStack.js
+++ b/maqetta.core.client/WebContent/davinci/commands/CommandStack.js
@@ -129,7 +129,7 @@ return declare("davinci.commands.CommandStack", null, {
 				}
 			}else{
 				while(n > 0){
-					this._undoStack.push(this._redoStack.push());
+					this._undoStack.push(this._redoStack.pop());
 					n--;
 				}
 			}


### PR DESCRIPTION
Corrects a logic error in CommandStack.jump()

I have a Dojo Foundation CCLA on file (Asseverate Services Limited/Kitson Kelly)
